### PR TITLE
Skip check remote versions before installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,19 @@ functionality will be restored.
 TOFUENV_REVERSE_REMOTE=1 tofuenv list-remote
 ```
 
+##### `TOFUENV_SKIP_LIST_REMOTE`
+
+Integer (Default: 0)
+
+Skip list remote versions in installation step. Can be useful for a custom remote, such as Artifactory.
+
+Disabled: 0
+Enable: any other value
+
+```console
+TOFUENV_SKIP_LIST_REMOTE=1 tofuenv install 1.6.0-rc1
+```
+
 ##### `TOFUENV_CONFIG_DIR`
 
 Path (Default: `$TOFUENV_ROOT`)

--- a/libexec/tofuenv-install
+++ b/libexec/tofuenv-install
@@ -74,12 +74,14 @@ declare regex="${resolved##*\:}";
 log 'debug' "Processing install for version ${version}, using regex ${regex}";
 
 if [[ ${version} =~ ${regex:-not} ]]; then
-  log 'debug' "Version and regex matched"
+  log 'debug' "Version and regex matched";
 else 
-  log 'debug' "Version and regex not matched"
-  remote_version="$(tofuenv-list-remote | grep -e "${regex}" | head -n 1)";
-  [ -n "${remote_version}" ] && version="${remote_version}" || log 'error' "No versions matching '${requested:-$version}' found in remote";
-fi
+  log 'debug' "Version and regex not matched";
+  if [ "${TOFUENV_SKIP_LIST_REMOTE:-0}" -eq 0 ]; then
+    remote_version="$(tofuenv-list-remote | grep -e "${regex}" | head -n 1)";
+    [ -n "${remote_version}" ] && version="${remote_version}" || log 'error' "No versions matching '${requested:-$version}' found in remote";
+  fi;
+fi;
 
 dst_path="${TOFUENV_CONFIG_DIR}/versions/${version}";
 if [ -f "${dst_path}/tofu" ]; then
@@ -181,7 +183,7 @@ case "${status}" in
     403) log 'error' "GitHub Rate limits exceeded" ;;
     404) log 'error' "No versions matching '${requested:-$version}' found in remote" ;;
     *)   log 'error' "Unknown error, status code = ${status}" ;;
-esac
+esac;
 
 log 'info' "Downloading SHA hash file from ${version_url}/${shasums_name}";
 curlw -s -f -L -o "${download_tmp}/${shasums_name}" "${version_url}/${shasums_name}" || log 'error' 'SHA256 hashes download failed';

--- a/libexec/tofuenv-install
+++ b/libexec/tofuenv-install
@@ -73,8 +73,13 @@ declare regex="${resolved##*\:}";
 
 log 'debug' "Processing install for version ${version}, using regex ${regex}";
 
-remote_version="$(tofuenv-list-remote | grep -e "${regex}" | head -n 1)";
-[ -n "${remote_version}" ] && version="${remote_version}" || log 'error' "No versions matching '${requested:-$version}' found in remote";
+if [[ ${version} =~ ${regex:-not} ]]; then
+  log 'debug' "Version and regex matched"
+else 
+  log 'debug' "Version and regex not matched"
+  remote_version="$(tofuenv-list-remote | grep -e "${regex}" | head -n 1)";
+  [ -n "${remote_version}" ] && version="${remote_version}" || log 'error' "No versions matching '${requested:-$version}' found in remote";
+fi
 
 dst_path="${TOFUENV_CONFIG_DIR}/versions/${version}";
 if [ -f "${dst_path}/tofu" ]; then
@@ -168,7 +173,16 @@ case "${TOFUENV_CURL_OUTPUT:-2}" in
 esac;
 
 log 'info' "Downloading release tarball from ${version_url}/${tarball_name}";
-curlw ${curl_progress} -f -L -o "${download_tmp}/${tarball_name}" "${version_url}/${tarball_name}" || log 'error' 'Tarball download failed';
+
+status=$(curlw ${curl_progress} -w "%{http_code}" -f -L -o "${download_tmp}/${tarball_name}" "${version_url}/${tarball_name}");
+
+case "${status}" in
+    200) log 'debug' "'${requested:-$version}' version download successfully" ;;
+    403) log 'error' "GitHub Rate limits exceeded" ;;
+    404) log 'error' "No versions matching '${requested:-$version}' found in remote" ;;
+    *)   log 'error' "Unknown error, status code = ${status}" ;;
+esac
+
 log 'info' "Downloading SHA hash file from ${version_url}/${shasums_name}";
 curlw -s -f -L -o "${download_tmp}/${shasums_name}" "${version_url}/${shasums_name}" || log 'error' 'SHA256 hashes download failed';
 


### PR DESCRIPTION
In some cases we can skip additional request to the GitHub api, and stay under the rate limit.

Added option `TOFUENV_SKIP_LIST_REMOTE` for have ability to skip list remote versions in installation step. 
Can be useful for a custom remote, such as Artifactory.